### PR TITLE
[FEAT] Default 200 OK인 성공 응답 팩토리 메소드 of 추가

### DIFF
--- a/src/main/java/io/roam/common/response/ErrorResponse.java
+++ b/src/main/java/io/roam/common/response/ErrorResponse.java
@@ -17,6 +17,7 @@ public record ErrorResponse(
      * 실패 응답
      *
      * @param errorCode ErrorCode Enum
+     * @return ErrorResponse 인스턴스
      */
     public static ErrorResponse of(@NonNull ErrorCode errorCode) {
         return new ErrorResponse(errorCode.getHttpStatus(), false, errorCode.getCode(), errorCode.getMessage());

--- a/src/main/java/io/roam/common/response/SuccessResponse.java
+++ b/src/main/java/io/roam/common/response/SuccessResponse.java
@@ -15,7 +15,9 @@ public record SuccessResponse<T>(
     /**
      * 성공 응답 (200 OK)
      *
+     * @param <T> 페이로드 타입
      * @param data payload
+     * @return HttpStatus.OK 상태와 페이로드를 포함한 SuccessResponse 인스턴스
      */
     public static <T> SuccessResponse<T> of(@Nullable T data) {
         return new SuccessResponse<>(HttpStatus.OK, true, data);
@@ -24,8 +26,10 @@ public record SuccessResponse<T>(
     /**
      * 성공 응답 (HttpStatus 설정 필요)
      *
+     * @param <T> 페이로드 타입
      * @param status HttpStatus Enum
      * @param data payload
+     * @return 지정한 HttpStatus와 페이로드를 포함한 SuccessResponse 인스턴스
      */
     public static <T> SuccessResponse<T> of(@NonNull HttpStatus status, @Nullable T data) {
         return new SuccessResponse<>(status, true, data);


### PR DESCRIPTION
## 🔎 관련 이슈
- #5 

## 📌 작업 내용
- Default 200 OK인 성공 응답 팩토리 메소드 of 추가
- SuccessResponse 주석 추가
- ErrorResponse 주석 추가

## 📝 기타
- 

## 📚 레퍼런스
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 기본 HTTP 상태 200 OK와 함께 페이로드를 포함하는 성공 응답을 생성하는 정적 팩토리 메서드가 추가되었습니다.

- **문서화**
  - 성공 및 오류 응답 관련 메서드에 대한 설명이 JavaDoc 주석으로 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->